### PR TITLE
Fix program not found on windows

### DIFF
--- a/support/sdl2_build_extra.py
+++ b/support/sdl2_build_extra.py
@@ -13,8 +13,8 @@ AlwaysBuild(env.Alias("upload", "$BUILD_DIR/${PROGNAME}", "$BUILD_DIR/${PROGNAME
 # Add custom target to explorer
 env.AddTarget(
     name = "execute",
-    dependencies = "$BUILD_DIR/${PROGNAME}",
-    actions = "$BUILD_DIR/${PROGNAME}",
+    dependencies = "$BUILD_DIR/${PROGNAME}.exe",
+    actions = "$BUILD_DIR/${PROGNAME}.exe",
     title = "Execute",
     description = "Build and execute",
     group="General"


### PR DESCRIPTION
On windows when you try to execute a demo it says *** [execute] Source `.pio\build\emulator_64bits\program' not found, needed by target `execute'.
So the execute fails. I fixed that with adding the .exe file extension to sdl2_build_extra.py file.