### PR TITLE
Update platformio.ini to use `build_src_filter`

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ lib_deps =
   ; Use direct URL, because package registry is unstable
   ;lv_drivers@~7.9.0
   lv_drivers=https://github.com/lvgl/lv_drivers/archive/refs/tags/v8.2.0.zip
-src_filter =
+build_src_filter =
   +<*>
   +<../hal/sdl2>
   ; Force compile LVGL demo, remove when working on your own project
@@ -67,7 +67,7 @@ extends = env:emulator_64bits
 build_flags =
   ${env:emulator_64bits.build_flags}
   -m32
-src_filter =
+build_src_filter =
   +<*>
   +<../hal/sdl2>
   +<../.pio/libdeps/emulator_32bits/lvgl/demos>
@@ -87,7 +87,7 @@ lib_deps =
   ${env.lib_deps}
   BSP-ili9341
   BSP-stmpe811
-src_filter =
+build_src_filter =
   +<*>
   +<../hal/stm32f429_disco>
   ; Force compile LVGL demo, remove when working on your own project


### PR DESCRIPTION
PlatformIO is deprecating `src_filter`. Use `build_src_filter` instead.
https://docs.platformio.org/en/latest/projectconf/section_env_build.html#build-src-filter