### PR TITLE
Add documentation for MacOS to load sdl drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Use [Homebrew](https://brew.sh/):
 brew install sdl2
 ```
 Note: 
-On mac os you need to include (uncomment in provided example platformio.ini file) these lines in your platformio.ini file to import the drivers:
-```; SDL2 includes
+On MacOS you need to include (uncomment in provided example platformio.ini file) these lines in your platformio.ini file to import the drivers:
+```
+  ; SDL2 includes
   !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /"
   !find /opt/homebrew/Cellar/sdl2 -name "libSDL2.a" | xargs dirname | sed "s/^/-L /"
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Use [Homebrew](https://brew.sh/):
 ```sh
 brew install sdl2
 ```
+Note: 
+On mac os you need to include (uncomment in provided example platformio.ini file) these lines in your platformio.ini file to import the drivers:
+```; SDL2 includes
+  !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /"
+  !find /opt/homebrew/Cellar/sdl2 -name "libSDL2.a" | xargs dirname | sed "s/^/-L /"
+```
 
 **Windows**
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -49,6 +49,10 @@ build_flags =
   ; LVGL memory options, setup for the demo to run properly
   -D LV_MEM_CUSTOM=1
   -D LV_MEM_SIZE="(128U * 1024U)"
+
+  ; SDL2 includes, uncomment the next two lines on MAC OS if you intalled sdl via homebrew
+  ;  !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /"
+  ;  !find /opt/homebrew/Cellar/sdl2 -name "libSDL2.a" | xargs dirname | sed "s/^/-L /"
   
 lib_deps =
   ${env.lib_deps}


### PR DESCRIPTION
An update of the documentation and platformio.ini file to get a working version of the project under MacOS with SDL installed via Homebrew