### PR TITLE
Update PlatformIO demo to LVGL9.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 3'
 
@@ -61,7 +62,7 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE=1 brew install sdl2
 
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v5
 
       - name: Install PlatformIO
         run: |

--- a/hal/stm32f429_disco/touchpad.c
+++ b/hal/stm32f429_disco/touchpad.c
@@ -24,7 +24,7 @@
 /**********************
  *  STATIC PROTOTYPES
  **********************/
-static void touchpad_read(lv_indev_drv_t * drv, lv_indev_data_t *data);
+static void touchpad_read(lv_indev_t * drv, lv_indev_data_t *data);
 static bool touchpad_get_xy(int16_t *x, int16_t *y);
 
 /**********************
@@ -47,11 +47,9 @@ void touchpad_init(void)
   stmpe811_Init(TS_I2C_ADDRESS);
   stmpe811_TS_Start(TS_I2C_ADDRESS);
 
-  lv_indev_drv_t indev_drv;
-  lv_indev_drv_init(&indev_drv);
-  indev_drv.read_cb = touchpad_read;
-  indev_drv.type = LV_INDEV_TYPE_POINTER;
-  lv_indev_drv_register(&indev_drv);
+  lv_indev_t  * indev_drv = lv_indev_create();
+  lv_indev_set_read_cb(indev_drv, touchpad_read);
+  lv_indev_set_type(indev_drv, LV_INDEV_TYPE_POINTER);
 }
 
 /**********************
@@ -65,7 +63,7 @@ void touchpad_init(void)
  * @param y put the y coordinate here
  * @return true: the device is pressed, false: released
  */
-static void touchpad_read(lv_indev_drv_t * drv, lv_indev_data_t *data)
+static void touchpad_read(lv_indev_t * dev, lv_indev_data_t *data)
 {
 	static int16_t last_x = 0;
 	static int16_t last_y = 0;

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,9 @@ lib_archive = false
 
 [env:emulator_64bits]
 platform = native@^1.1.3
-extra_scripts = support/sdl2_build_extra.py
+extra_scripts = 
+  pre:support/sdl2_paths.py ; Tries to find SDL2 include and lib paths on your system - specifically for MacOS w/ Homebrew
+  post:support/sdl2_build_extra.py
 build_flags =
   ${env.build_flags}
   ; -D LV_LOG_LEVEL=LV_LOG_LEVEL_INFO
@@ -48,10 +50,6 @@ build_flags =
   ; LVGL memory options, setup for the demo to run properly
   -D LV_MEM_CUSTOM=1
   -D LV_MEM_SIZE="(128U * 1024U)"
-
-  ; SDL2 includes, uncomment the next two lines on MAC OS if you intalled sdl via homebrew
-  ;  !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /"
-  ;  !find /opt/homebrew/Cellar/sdl2 -name "libSDL2.a" | xargs dirname | sed "s/^/-L /"
   
 lib_deps =
   ${env.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,8 +22,7 @@ build_flags =
   ; Add more defines below to overide lvgl:/src/lv_conf_simple.h
 lib_deps =
   ; Use direct URL, because package registry is unstable
-  ;lvgl@~7.11.0
-  lvgl=https://github.com/lvgl/lvgl/archive/refs/tags/v8.2.0.zip
+  lvgl@9.1
 lib_archive = false
 
 
@@ -40,11 +39,11 @@ build_flags =
   ; SDL drivers options
   -D LV_LVGL_H_INCLUDE_SIMPLE
   -D LV_DRV_NO_CONF
-  -D USE_SDL
+  -D LV_USE_SDL
   -D SDL_HOR_RES=480
   -D SDL_VER_RES=320  
   -D SDL_ZOOM=1
-  -D SDL_INCLUDE_PATH="\"SDL2/SDL.h\""
+  -D LV_SDL_INCLUDE_PATH="\"SDL2/SDL.h\""
 
   ; LVGL memory options, setup for the demo to run properly
   -D LV_MEM_CUSTOM=1
@@ -56,9 +55,6 @@ build_flags =
   
 lib_deps =
   ${env.lib_deps}
-  ; Use direct URL, because package registry is unstable
-  ;lv_drivers@~7.9.0
-  lv_drivers=https://github.com/lvgl/lv_drivers/archive/refs/tags/v8.2.0.zip
 build_src_filter =
   +<*>
   +<../hal/sdl2>

--- a/support/sdl2_paths.py
+++ b/support/sdl2_paths.py
@@ -1,0 +1,27 @@
+Import("env")
+import sys
+import os
+import glob
+
+if sys.platform.startswith("darwin"):
+    #sdl_include_path = !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /"
+    sdl_include = glob.glob("/opt/homebrew/Cellar/sdl2/*/include", recursive=True)
+    if sdl_include:
+        print(f"Found Homebrew SDL include path: {sdl_include[0]}")
+        env.Append(
+            CPPPATH=sdl_include[0]
+        )
+    sdl_lib = glob.glob("/opt/homebrew/Cellar/sdl2/**/libSDL2.a", recursive=True)
+    if sdl_lib:
+        print(f"Found Homebrew SDL lib path: {sdl_lib[0]}")
+        env.Append(
+            LIBPATH=os.path.dirname(sdl_lib[0])
+        )
+    
+    
+#breakpoint()
+    
+#print('NewENV=====================================')
+#print(env.Dump())
+#print('DefaultENV=====================================')
+#print(DefaultEnvironment().Dump())


### PR DESCRIPTION
This pull request updates lv_platformio demo to use lvgl 9.1. The changes that are required are:
- Bump lvgl version from 8.2 to 9.1
- Remove dependency of `lv_drivers`. Lvgl 9+ has these included in the main repo under `src/drivers`
- Simplify the SDL demo as the driver in 9+ provides `lv_sdl_window_create` et.al. which takes care of proper creation and initialization of a window and input devices
- Update the demo for the lvgl 8->9 transition (e.g. `lv_disp_drv_t` -> `lv_display_t`, `lv_indev_drv_t` -> `lv_indev_t`)

**NB!:** SDL demo has been tested only on MacOS and Linux. I've also updated the STM Discovery demo to compile and very similar code works on other boards, but I don't have that particular board to test.